### PR TITLE
Fix Bug that validates empty non-required inputs

### DIFF
--- a/vendor/Luracast/Restler/Data/Validator.php
+++ b/vendor/Luracast/Restler/Data/Validator.php
@@ -361,7 +361,7 @@ class Validator implements iValidate
         $html = Scope::get('Restler')->responseFormat instanceof HtmlFormat;
         $name = $html ? "<strong>$info->label</strong>" : "`$info->name`";
         try {
-            if (is_null($input)) {
+            if (is_null($input) || !$input) {
                 if ($info->required) {
                     throw new RestException (400,
                         "$name is required.");


### PR DESCRIPTION
Restler validated optional parameters and threw an error if the input was empty. Now, this behavior is fixed.
